### PR TITLE
Update to accommodate SSP's schedule change

### DIFF
--- a/src/pfs_obsproc_planning/opefile.py
+++ b/src/pfs_obsproc_planning/opefile.py
@@ -122,6 +122,7 @@ class OpeFile(object):
             repl2_single_line = (
                 f'{val[0]}=OBJECT="{val[0]}" RA={val[4]} DEC={val[5]} EQUINOX=2000.0'
             )
+            # register the OBJECT if it is not already in the list
             if repl2_single_line not in repl2:
                 repl2 += repl2_single_line + "\n"
         self.contents1_updated = self.contents1_updated.replace(repl1, repl2)

--- a/src/pfs_obsproc_planning/opefile.py
+++ b/src/pfs_obsproc_planning/opefile.py
@@ -119,9 +119,11 @@ class OpeFile(object):
         )
         repl2 = ""
         for i, val in enumerate(info):
-            repl2 += (
-                f'{val[0]}=OBJECT="{val[0]}" RA={val[4]} DEC={val[5]} EQUINOX=2000.0\n'
+            repl2_single_line = (
+                f'{val[0]}=OBJECT="{val[0]}" RA={val[4]} DEC={val[5]} EQUINOX=2000.0'
             )
+            if repl2_single_line not in repl2:
+                repl2 += repl2_single_line + "\n"
         self.contents1_updated = self.contents1_updated.replace(repl1, repl2)
 
         # remove unnecessary words

--- a/src/pfs_obsproc_planning/opefile.py
+++ b/src/pfs_obsproc_planning/opefile.py
@@ -118,13 +118,19 @@ class OpeFile(object):
             'FIELD_NAME=OBJECT="FIELD_NAME" RA=FIELD_RA DEC=FIELD_DEC EQUINOX=2000.0'
         )
         repl2 = ""
+        object_names = []
         for i, val in enumerate(info):
             repl2_single_line = (
                 f'{val[0]}=OBJECT="{val[0]}" RA={val[4]} DEC={val[5]} EQUINOX=2000.0'
             )
             # register the OBJECT if it is not already in the list
             if repl2_single_line not in repl2:
+                object_names.append(val[0])
                 repl2 += repl2_single_line + "\n"
+        if len(object_names) != len(set(object_names)):
+            raise ValueError(
+                f"Duplicate PPC codes with different coordinates and/or EQUINOX found ppc_code={object_names}"
+            )
         self.contents1_updated = self.contents1_updated.replace(repl1, repl2)
 
         # remove unnecessary words

--- a/src/pfs_obsproc_planning/validation.py
+++ b/src/pfs_obsproc_planning/validation.py
@@ -59,6 +59,9 @@ def calc_inr(df):
             0.0,
             0.0,
         )
+    except ValueError as e:
+        logger.warning(f"Error in calculating InR: {e}")
+        inr = np.nan
     return inr
 
 


### PR DESCRIPTION
- More exact date string check for `ppc_obstime`. It check if the string contains `YYYY-MM-DD` format and can be converted to datetime object.
- Set `inr=np.nan` when `obstime` is set to `nan`.
- Remove duplicated OBJECT definition from the output OPE file.
- Check uniquenss of OBJECTs in the output OPE file.
