### PR TITLE
Organzie PPC observing dates according to night assignments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,135 @@
+# Common settings that generally should always be used with your language specific settings
+
+# Auto detect text files and perform LF normalization
+*          text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+
+# Basic .gitattributes for a python repo.
+
+# Source files
+# ============
+*.pxd    text diff=python
+*.py     text diff=python
+*.py3    text diff=python
+*.pyw    text diff=python
+*.pyx    text diff=python
+*.pyz    text diff=python
+*.pyi    text diff=python
+
+# Binary files
+# ============
+*.db     binary
+*.p      binary
+*.pkl    binary
+*.pickle binary
+*.pyc    binary export-ignore
+*.pyo    binary export-ignore
+*.pyd    binary
+
+# Jupyter notebook
+*.ipynb  text eol=lf
+
+# Note: .db, .p, and .pkl files are associated
+# with the python modules ``pickle``, ``dbm.*``,
+# ``shelve``, ``marshal``, ``anydbm``, & ``bsddb``
+# (among others).
+
+# Apply override to all files in the directory
+*.md linguist-detectable
+
+# FITS files
+*.fits binary
+

--- a/src/pfs_obsproc_planning/generatePfsDesign_ssp.py
+++ b/src/pfs_obsproc_planning/generatePfsDesign_ssp.py
@@ -967,7 +967,7 @@ class GeneratePfsDesign_ssp(object):
             for format_str in formats:
                 try:
                     return datetime.strptime(date_string, format_str)
-                except ValueError:
+                except (ValueError, TypeError):
                     continue
             # If none of the formats worked
             raise ValueError(

--- a/src/pfs_obsproc_planning/generatePfsDesign_ssp.py
+++ b/src/pfs_obsproc_planning/generatePfsDesign_ssp.py
@@ -595,10 +595,13 @@ class GeneratePfsDesign_ssp(object):
         # read ppcList.ecsv
         tb_ppc = Table.read(os.path.join(self.workDir, "targets", WG, "ppcList.ecsv"))
 
-        mask = np.array([
-            (isinstance(val, str) and val.strip().lower() != "nan") or not (isinstance(val, str))
-            for val in tb_ppc["ppc_obstime"]
-        ])  # True for pointings that are not NaN or "nan" in obstime
+        mask = np.array(
+            [
+                (isinstance(val, str) and val.strip().lower() != "nan")
+                or not (isinstance(val, str))
+                for val in tb_ppc["ppc_obstime"]
+            ]
+        )  # True for pointings that are not NaN or "nan" in obstime
         tb_ppc = tb_ppc[mask]
 
         # Convert each timestamp from HST to UTC
@@ -942,76 +945,99 @@ class GeneratePfsDesign_ssp(object):
 
     def makeope(self, tb_ppc):
         def is_valid_date_format(date_string):
-            if date_string is None or not isinstance(date_string, str):
+            """Check if string starts with a valid YYYY-MM-DD date format."""
+            if not isinstance(date_string, str):
                 return False
-            # YYYY-MM-DD pattern
-            date_pattern = r"^\d{4}-\d{2}-\d{2}"
-            if re.match(date_pattern, date_string):
-                # Check date string
-                try:
-                    # First 10 characters for the format check
-                    date_part = date_string[:10]
-                    datetime.strptime(date_part, "%Y-%m-%d")
-                    return True
-                except ValueError:
-                    return False
-            return False
+            try:
+                # Just validate the first 10 chars as a date
+                datetime.strptime(date_string[:10], "%Y-%m-%d")
+                return True
+            except (ValueError, TypeError):
+                return False
 
-        ## ope file generation ##
-        ope = OpeFile(conf=self.conf, workDir=self.workDir)
-        obsdates = list(
-            set(
-                [row[:10] for row in tb_ppc["ppc_obstime"] if is_valid_date_format(row)]
+        def parse_datetime(date_string):
+            formats = [
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%dT%H:%M:%SZ",
+                "%Y-%m-%dT%H:%M:%S.%f",
+                "%Y-%m-%dT%H:%M:%S",
+                "%Y-%m-%d %H:%M:%S.%f",
+            ]
+            # check if the date_string is in one of the possible formats
+            for format_str in formats:
+                try:
+                    return datetime.strptime(date_string, format_str)
+                except ValueError:
+                    continue
+            # If none of the formats worked
+            raise ValueError(
+                f"Time data '{date_string}' does not match any known format"
             )
-        )
+
+        # Define the Hawaii timezone (HST is always UTC-10, no DST)
+        hawaii_tz = pytz.timezone("Pacific/Honolulu")
+
+        def hst_to_utc(hst_string):
+            """Convert HST datetime string to UTC datetime strings (full and date only)."""
+            try:
+                dt_naive = parse_datetime(hst_string)
+                dt_utc = hawaii_tz.localize(dt_naive).astimezone(pytz.utc)
+                return dt_utc.strftime("%Y-%m-%d %H:%M:%S"), dt_utc.strftime("%Y-%m-%d")
+            except ValueError:
+                return np.nan, np.nan
+
+        # Convert ppc_obstime (HST) to UTC
+        _obstime_utc = []
+        _obsdate_utc = []
+        for hst_string in tb_ppc["ppc_obstime"]:
+            full_time, date_only = hst_to_utc(hst_string)
+            _obstime_utc.append(full_time)
+            _obsdate_utc.append(date_only)
+
+        # Update dataframe
         tb_ppc["ppc_obsdate"] = [
             row[:10] if is_valid_date_format(row) else np.nan
             for row in tb_ppc["ppc_obstime"]
         ]
-        for obsdate in obsdates:
-            logger.info(f"[Make ope] generating ope file for {obsdate}...")
+        tb_ppc["ppc_obstime_utc_from_hst"] = _obstime_utc
+        tb_ppc["ppc_obsdate_utc_from_hst"] = _obsdate_utc
+
+        # Get unique dates more concisely
+        def get_unique_dates(date_column):
+            """Extract unique valid dates from a column."""
+            return sorted(
+                {date[:10] for date in date_column if is_valid_date_format(date)}
+            )
+
+        obsdates = get_unique_dates(tb_ppc["ppc_obstime"])
+        obsdates_utc = get_unique_dates(tb_ppc["ppc_obsdate_utc_from_hst"])
+
+        ## ope file generation ##
+        ope = OpeFile(conf=self.conf, workDir=self.workDir)
+
+        for obsdate_utc in obsdates_utc:
+            logger.info(f"[Make ope] generating ope file for {obsdate_utc} (UTC)...")
             template_file = (
                 self.conf["ope"]["template"]
                 if os.path.exists(self.conf["ope"]["template"])
                 else None
             )
             ope.loadTemplate(filename=template_file)  # initialize
-            ope.update_obsdate(obsdate)  # update observation date
+            ope.update_obsdate(obsdate_utc, utc=True)  # update observation date
 
-            tb_ppc_t = tb_ppc[tb_ppc["ppc_obsdate"] == obsdate]
+            tb_ppc_t = tb_ppc[tb_ppc["ppc_obsdate_utc_from_hst"] == obsdate_utc]
 
             tb_ppc_t["obsdate_in_hst"] = tb_ppc_t["ppc_obsdate"]
+            tb_ppc_t["obsdate_in_utc"] = tb_ppc_t["ppc_obsdate_utc_from_hst"]
+            tb_ppc_t["obstime_in_utc"] = tb_ppc_t["ppc_obstime_utc_from_hst"]
 
-            # Define the Hawaii timezone (HST is always UTC-10, no DST)
-            hawaii_tz = pytz.timezone("Pacific/Honolulu")
-
-            # Convert each timestamp from HST to UTC
-            ppc_obstime_utc = []
-            for hst_string in tb_ppc_t["ppc_obstime"]:
-                try:
-                    dt_naive = datetime.strptime(hst_string, "%Y-%m-%d %H:%M:%S")
-                except ValueError:
-                    try:
-                        dt_naive = datetime.strptime(hst_string, "%Y-%m-%dT%H:%M:%SZ")
-                    except ValueError:
-                        try:
-                            dt_naive = datetime.strptime(
-                                hst_string, "%Y-%m-%dT%H:%M:%S.%f"
-                            )
-                        except ValueError:
-                            try:
-                                dt_naive = datetime.strptime(
-                                    hst_string, "%Y-%m-%dT%H:%M:%S"
-                                )
-                            except ValueError:
-                                dt_naive = datetime.strptime(
-                                    hst_string, "%Y-%m-%d %H:%M:%S.%f"
-                                )
-                dt_hst = hawaii_tz.localize(dt_naive)
-                dt_utc = dt_hst.astimezone(pytz.utc)
-                ppc_obstime_utc.append(dt_utc.strftime("%Y-%m-%d %H:%M:%S"))
-
-            tb_ppc_t["obstime_in_utc"] = ppc_obstime_utc
+            if np.unique(tb_ppc_t["obsdate_in_utc"]).size > 1:
+                logger.error(
+                    f"Multiple unique UTC times found for {obsdate_utc} ({tb_ppc_t['obstime_in_utc_from_hst']=}) . This may lead to unexpected behavior."
+                )
+                raise ValueError(
+                    f"Multiple unique UTC times found for the same UTC obsdate ({obsdate_utc}). Please check the input ppc_obstime values."
+                )
 
             tb_ppc_t["pfs_design_id"] = tb_ppc_t["pfsDesignId"]
             tb_ppc_t["obstime_in_hst"] = tb_ppc_t["ppc_obstime"]

--- a/src/pfs_obsproc_planning/opefile.py
+++ b/src/pfs_obsproc_planning/opefile.py
@@ -60,7 +60,14 @@ class OpeFile(object):
                 elif science_part == 2:
                     self.contents3 += line
 
-    def update_obsdate(self, obsdate):
+    def update_obsdate(self, obsdate, utc=False):
+        obsdate_orig = obsdate
+        if utc:
+            # NOTE: A night in HST is safely assumed to be always the same day in UTC
+            # convert obsdate (YYYY-MM-DD) to UTC and subtract 1 day
+            obstime_hst = Time(obsdate) - TimeDelta(1.0 * u.day)
+            obsdate = obstime_hst.strftime("%Y-%m-%d")
+
         # name of OPE file
         self.outfile = os.path.join(self.outfilePath, f"{obsdate}.ope")
 


### PR DESCRIPTION
This PR fixes the wrong (or confusing) organization of observation time to follow the night assignment. 

ppc observation times are now worked in UTC when generating OPE files. Here, a strong assumption is that ppc_obstime is always HST and a night in HST is a single UTC date. We may need to make it more general case, but for HST-UTC lists, it should be fine.

I also added .gitattributes file for various filetypes (I had a problem between CRLF and LF line-ending difference).

(He-san, you don't need to merge immedidately as I modified some of the logic in the `makeope()` and added `utc` flag to `ope.update_obsdate()`)