### PR TITLE
fix script's entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ readme = "README.md"
 license = { text = "MIT" }
 
 [project.scripts]
-pfs-packages = "pfs_obsproc_planning.pfs_packages:main"
+pfs-packages = "pfs_obsproc_planning.utils.pfs_packages:main"
 
 [build-system]
 requires = ["pybind11", "setuptools", "setuptools_scm", "wheel"]


### PR DESCRIPTION
This pull request updates the script entry point for `pfs-packages` in the `pyproject.toml` file to reference its new location in the codebase.

- Configuration update:
  * Changed the `pfs-packages` script entry point to point to `pfs_obsproc_planning.utils.pfs_packages:main` instead of `pfs_obsproc_planning.pfs_packages:main` in `pyproject.toml`.