### PR TITLE
Update to ECSV format following Astropy 8.0.0 changes

### DIFF
--- a/src/pfs_obsproc_planning/generatePfsDesign.py
+++ b/src/pfs_obsproc_planning/generatePfsDesign.py
@@ -589,9 +589,9 @@ class GeneratePfsDesign(object):
         self.update_config()
 
         ## get a list of OBs ##
-        t1 = Table.read(os.path.join(self.outputDirPPP, "obList.ecsv"))
+        t1 = Table.read(os.path.join(self.outputDirPPP, "obList.ecsv"), format="ecsv")
         try:
-            t2 = Table.read(os.path.join(self.outputDirPPP, "obList_backup.ecsv"))
+            t2 = Table.read(os.path.join(self.outputDirPPP, "obList_backup.ecsv"), format="ecsv")
         except Exception:
             t2 = Table()
         t = vstack([t1, t2])
@@ -718,10 +718,10 @@ class GeneratePfsDesign(object):
         logger.info(len(obList))
 
         ## get a list of assigned OBs ## FIXME (maybe we don't need to use this)
-        tb_ppp = Table.read(os.path.join(self.outputDirPPP, "ppcList.ecsv"))
+        tb_ppp = Table.read(os.path.join(self.outputDirPPP, "ppcList.ecsv"), format="ecsv")
         try:
             tb_ppp_backup = Table.read(
-                os.path.join(self.outputDirPPP, "ppcList_backup.ecsv")
+                os.path.join(self.outputDirPPP, "ppcList_backup.ecsv"), format="ecsv"
             )
         except Exception:
             tb_ppp_backup = Table()

--- a/src/pfs_obsproc_planning/generatePfsDesign_ssp.py
+++ b/src/pfs_obsproc_planning/generatePfsDesign_ssp.py
@@ -694,13 +694,13 @@ class GeneratePfsDesign_ssp(object):
             )
             return Table(), Table(), Table()
         else:
-            tb_sci = Table.read(filepath_sci)
+            tb_sci = Table.read(filepath_sci, format="ecsv")
 
         if not os.path.isfile(filepath_sky):
             logger.error(f"[read_tgt] Missing sky file for {ppc_code}: {filepath_sky}")
             return Table(), Table(), Table()
         else:
-            tb_sky = Table.read(filepath_sky)
+            tb_sky = Table.read(filepath_sky, format="ecsv")
 
         if not os.path.isfile(filepath_fluxstd):
             logger.error(
@@ -708,7 +708,7 @@ class GeneratePfsDesign_ssp(object):
             )
             return Table(), Table(), Table()
         else:
-            tb_fluxstd = Table.read(filepath_fluxstd)
+            tb_fluxstd = Table.read(filepath_fluxstd, format="ecsv")
 
         tb_sci["cidx"] = tb_sci["cobraId"] - 1
         tb_sky["cidx"] = tb_sky["cobraId"] - 1
@@ -885,7 +885,7 @@ class GeneratePfsDesign_ssp(object):
         ppc_path = os.path.join(self.workDir, "targets", WG, "ppcList.ecsv")
 
         try:
-            tb_ppc = Table.read(ppc_path)
+            tb_ppc = Table.read(ppc_path, format="ecsv")
         except Exception:
             logger.error(f"Missing ppcList.ecsv for WG={WG}: {ppc_path}")
             return Table()
@@ -1298,7 +1298,7 @@ class GeneratePfsDesign_ssp(object):
             ppc_path = os.path.join(self.workDir, "targets", wg_, "ppcList.ecsv")
 
             if os.path.exists(ppc_path):
-                tb_ppc = Table.read(ppc_path)
+                tb_ppc = Table.read(ppc_path, format="ecsv")
             else:
                 logger.error(
                     f"[Validation of ppcList] ({wg_}) File not found: {ppc_path}"

--- a/src/pfs_obsproc_planning/utils/build_target.py
+++ b/src/pfs_obsproc_planning/utils/build_target.py
@@ -242,13 +242,13 @@ def visibility_checker(tb_tgt, obstimes, start_time_list, stop_time_list):
 
 def load_user_ppc_table(path_ppc):
     if path_ppc.endswith(".ecsv"):
-        return Table.read(path_ppc)
+        return Table.read(path_ppc, format="ecsv")
 
     from glob import glob
 
     tables = []
     for index, file in enumerate(glob(path_ppc + "*"), start=1):
-        tbl = Table.read(file)
+        tbl = Table.read(file, format="ecsv")
         tbl["ppc_code"] = [f"{code}_{index}" for code in tbl["ppc_code"]]
         tables.append(tbl)
 

--- a/src/pfs_obsproc_planning/utils/build_target.py
+++ b/src/pfs_obsproc_planning/utils/build_target.py
@@ -248,7 +248,10 @@ def load_user_ppc_table(path_ppc):
 
     tables = []
     for index, file in enumerate(glob(path_ppc + "*"), start=1):
-        tbl = Table.read(file, format="ecsv")
+        if file.endswith(".ecsv"):
+            tbl = Table.read(file, format="ecsv")
+        else:
+            tbl = Table.read(file)
         tbl["ppc_code"] = [f"{code}_{index}" for code in tbl["ppc_code"]]
         tables.append(tbl)
 

--- a/src/pfs_obsproc_planning/utils/completion_check.py
+++ b/src/pfs_obsproc_planning/utils/completion_check.py
@@ -24,17 +24,17 @@ warnings.filterwarnings("ignore")
 
 def run(conf, workDir="."):
     # read obList
-    tb_tgt = Table.read(os.path.join(workDir, "ppp/obList_tot.ecsv"))
+    tb_tgt = Table.read(os.path.join(workDir, "ppp/obList_tot.ecsv"), format="ecsv")
     try:
-        tb_tgt_backup = Table.read(os.path.join(workDir, "ppp/obList_backup.ecsv"))
+        tb_tgt_backup = Table.read(os.path.join(workDir, "ppp/obList_backup.ecsv"), format="ecsv")
     except Exception:
         tb_tgt_backup = Table()
     tb_tgt = vstack([tb_tgt, tb_tgt_backup])
 
     # read ppclist
-    tb_ppc = Table.read(os.path.join(workDir, "ppp/ppcList.ecsv"))
+    tb_ppc = Table.read(os.path.join(workDir, "ppp/ppcList.ecsv"), format="ecsv")
     try:
-        tb_ppc_backup = Table.read(os.path.join(workDir, "ppp/ppcList_backup.ecsv"))
+        tb_ppc_backup = Table.read(os.path.join(workDir, "ppp/ppcList_backup.ecsv"), format="ecsv")
     except Exception:
         tb_ppc_backup = Table()
     tb_ppc = vstack([tb_ppc, tb_ppc_backup])

--- a/src/pfs_obsproc_planning/utils/validation.py
+++ b/src/pfs_obsproc_planning/utils/validation.py
@@ -468,7 +468,7 @@ def _load_ppp_targets_qa_reference_n(parentPath: str) -> pd.DataFrame:
         return pd.DataFrame()
 
     try:
-        tbl = Table.read(oblist_path, format="ascii.ecsv")
+        tbl = Table.read(oblist_path, format="ecsv")
         df = tbl.to_pandas()
     except Exception as e:
         logger.warning(f"Failed to read PPP obList.ecsv ({oblist_path}): {e}")


### PR DESCRIPTION
This pull request standardizes how ECSV files are read throughout the codebase by explicitly specifying the `format="ecsv"` argument in all `Table.read` calls. This change improves code clarity and robustness by ensuring the correct format is always used, which helps prevent subtle bugs if the default format handling changes or if files are misinterpreted.

**Standardization of ECSV file reading:**

* All instances of `Table.read` that load `.ecsv` files in `generatePfsDesign.py`, `generatePfsDesign_ssp.py`, `build_target.py`, `completion_check.py`, and `validation.py` now explicitly specify `format="ecsv"` to ensure consistent and correct parsing. [[1]](diffhunk://#diff-310036e4892c0190983165b90199d7dc738b0692ace28471ae3879e8ef18fecbL592-R594) [[2]](diffhunk://#diff-310036e4892c0190983165b90199d7dc738b0692ace28471ae3879e8ef18fecbL721-R724) [[3]](diffhunk://#diff-fbba4283959cf27304833022b27a84d83d8e1a23ac801ca77f553b07e7b4db71L697-R711) [[4]](diffhunk://#diff-fbba4283959cf27304833022b27a84d83d8e1a23ac801ca77f553b07e7b4db71L888-R888) [[5]](diffhunk://#diff-fbba4283959cf27304833022b27a84d83d8e1a23ac801ca77f553b07e7b4db71L1301-R1301) [[6]](diffhunk://#diff-27dab359abcd834524fca351305ef8b2f4a9fb9ef51e714675c46d7b76ff5fd4L245-R251) [[7]](diffhunk://#diff-ea2a0805724f114bad9bb89803576a8a091772a65921cdec3c314a4bc0b37fc2L27-R37) [[8]](diffhunk://#diff-a11bfee6fc3ebd25b534f323334e8244f9b38e60114fd02377de74555f9bb0e5L471-R471)